### PR TITLE
Use wget in Dockerfile instead of curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ADD files/php-fpm.conf /etc/php/
 ADD files/run.sh /
 RUN chmod +x /run.sh
 
-RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x wp-cli.phar && mv wp-cli.phar /usr/bin/wp-cli
+RUN wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x wp-cli.phar && mv wp-cli.phar /usr/bin/wp-cli
 
 EXPOSE 80
 VOLUME ["/DATA"]


### PR DESCRIPTION
I tried to build this locally and I got:

```
Step 12 : RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x wp-cli.phar && mv wp-cli.phar /usr/bin/wp-cli
 ---> Running in 53055d9a3e2e
/bin/sh: curl: not found
```
